### PR TITLE
libtsk compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -105,8 +105,8 @@ fn windows_compile_tsk() {
 
 #[cfg(target_os = "windows")]
 fn windows_setup() {
-    // windows_compile_tsk();
-    println!(r"cargo:rustc-link-search=sleuthkit\win32\x64\Release_NoLibs");
+    windows_compile_tsk();
+    println!(r"cargo:rustc-link-search={}\sleuthkit\win32\x64\Release_NoLibs", env::var("CARGO_MANIFEST_DIR").unwrap());
 
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let sdk_key = hklm.open_subkey(r"SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0")


### PR DESCRIPTION
Fix up libtsk's compilation and linking as part of Rust's build process. It can now be used directly by adding `libtisk-rs` as a dependency in Cargo.toml, without first building libtsk manually in Visual Studio.

Due to a custom step inside libtsk.vcxproj that checks for NuGet dependencies, I had to patch that file to make it work when compiling a `NoLibs` configuration (see https://github.com/sleuthkit/sleuthkit/pull/2205)