### PR TITLE
Add support for x86

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -66,7 +66,7 @@ fn main() {
 }
 
 #[cfg(target_os = "windows")]
-fn windows_compile_tsk() {
+fn windows_compile_tsk(target_arch: &str) {
     // First we need the x86 program path
     let program_path = PathBuf::from(
         std::env::var("ProgramFiles(x86)")
@@ -102,7 +102,13 @@ fn windows_compile_tsk() {
         .args(&[
             r"-target:libtsk",
             r"/p:PlatformToolset=v142",
-            r"/p:Platform=x64",
+
+            if target_arch == "x86" {
+                r"/p:Platform=Win32"
+            } else {
+                r"/p:Platform=x64"
+            },
+
             r"/p:Configuration=Release_NoLibs",
             r"/p:RestorePackages=false",
             r"sleuthkit\win32\tsk-win.sln"
@@ -115,9 +121,16 @@ fn windows_compile_tsk() {
 
 #[cfg(target_os = "windows")]
 fn windows_setup() {
-    windows_compile_tsk();
-    println!(r"cargo:rustc-link-search={}\sleuthkit\win32\x64\Release_NoLibs", env::var("CARGO_MANIFEST_DIR").unwrap());
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
+    windows_compile_tsk(&target_arch);
+
+    if target_arch == "x86" {
+        println!(r"cargo:rustc-link-search={}\sleuthkit\win32\Release_NoLibs", env::var("CARGO_MANIFEST_DIR").unwrap());
+    } else {
+        println!(r"cargo:rustc-link-search={}\sleuthkit\win32\x64\Release_NoLibs", env::var("CARGO_MANIFEST_DIR").unwrap());
+    }
+    
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let sdk_key = hklm.open_subkey(r"SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0")
         .expect("Microsoft SDK v10 is required.");
@@ -131,7 +144,12 @@ fn windows_setup() {
         .expect("Cant get ProductVersion");
     eprintln!("product_version: {}", product_version);
 
-    let sdk_path = format!(r"{}Lib\{}.0\um\x64", &installation_folder, &product_version);
+    let sdk_path = if target_arch == "x86" {
+        format!(r"{}Lib\{}.0\um\x86", &installation_folder, &product_version)
+    } else {
+        format!(r"{}Lib\{}.0\um\x64", &installation_folder, &product_version)
+    };
+
     eprintln!("sdk_path: {}", &sdk_path);
 
     println!(r"cargo:rustc-link-search={}", sdk_path);

--- a/src/tsk_fs_attr.rs
+++ b/src/tsk_fs_attr.rs
@@ -145,7 +145,7 @@ impl<'fs, 'f> Read for TskFsAttr<'fs, 'f> {
             self.tsk_fs_attr,
             self._offset,
             buf.as_mut_ptr() as _,
-            read_size,
+            read_size.try_into().unwrap(),
             tsk::TSK_FS_FILE_READ_FLAG_ENUM::TSK_FS_FILE_READ_FLAG_NONE
         )};
 
@@ -163,7 +163,7 @@ impl<'fs, 'f> Read for TskFsAttr<'fs, 'f> {
             );
         }
         // update offset by the number of bytes read
-        self._offset += bytes_read;
+        self._offset += bytes_read as i64;
 
         Ok(bytes_read as usize)
     }

--- a/src/tsk_fs_dir.rs
+++ b/src/tsk_fs_dir.rs
@@ -141,7 +141,7 @@ impl<'fs> Iterator for IntoDirNameIter<'fs> {
         let tsk_fs_dir_ptr: *mut tsk::TSK_FS_DIR = self.tsk_fs_dir.as_mut_ptr();
         let names_used =  unsafe {(*tsk_fs_dir_ptr).names_used};
 
-        if self.index < names_used {
+        if self.index < names_used.into() {
             // Get the pointer to the TSK_FS_NAME from the names array at the given index
             let ptr = unsafe {(*tsk_fs_dir_ptr).names.offset(self.index as isize)};
 
@@ -178,7 +178,7 @@ impl<'fs, 'd> Iterator for DirNameIter<'fs, 'd> {
     fn next(&mut self) -> Option<TskFsName> {
         let tsk_fs_dir_ptr: *mut tsk::TSK_FS_DIR = self.tsk_fs_dir.into();
 
-        while self.index < unsafe {(*tsk_fs_dir_ptr).names_used} {
+        while self.index < unsafe {(*tsk_fs_dir_ptr).names_used.into()} {
             // Get the pointer to the TSK_FS_NAME from the names array at the given index
             let ptr = unsafe {(*tsk_fs_dir_ptr).names.offset(self.index as isize)};
 

--- a/src/tsk_fs_file_handle.rs
+++ b/src/tsk_fs_file_handle.rs
@@ -2,6 +2,7 @@
 
 use std::io::{Read, Seek, SeekFrom};
 use std::ffi::CStr;
+use std::convert::TryInto;
 use super::{
     tsk_fs_file::TskFsFile,
     tsk_fs_attr::TskFsAttr,
@@ -53,7 +54,7 @@ impl<'f, 'fs> Read for TskFsFileHandle<'f, 'fs> {
             self.tsk_fs_attr.id(),
             self._offset,
             buf.as_mut_ptr() as *mut i8,
-            buf.len() as u64,
+            buf.len().try_into().unwrap(),
             self.read_flag
         )};
         match bytes_read {
@@ -71,7 +72,7 @@ impl<'f, 'fs> Read for TskFsFileHandle<'f, 'fs> {
                 ));
             }
             _ => {
-                    self._offset+=bytes_read;
+                    self._offset += bytes_read as i64;
                     return Ok(bytes_read as usize);
                 }
         };


### PR DESCRIPTION
Compile with `--target=i686-pc-windows-msvc`.

This required changes in compilation, and in some of the wrapping (since x86 affects types in bindings).

I tested the unit tests on Windows 10 x86