### PR TITLE
Feature/updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0]
+### Added
+- `TskImg::from_tsk_img_info_ptr()` to create a TskImg from `NonNull<tsk::TSK_IMG_INFO>`
+- imported `tsk_img_open_external` tsk function
+- imported tsk structs now derive debug and default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0]
+## [0.2.0]
 ### Added
 - `TskImg::from_tsk_img_info_ptr()` to create a TskImg from `NonNull<tsk::TSK_IMG_INFO>`
 - imported `tsk_img_open_external` tsk function
 - imported tsk structs now derive debug and default
+
+## [0.1.0]
+### Added
+- Initial Version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["matthew seyer <https://github.com/forensicmatt/libtsk-rs>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["matthew seyer <https://github.com/forensicmatt/libtsk-rs>"]
 edition = "2018"
 

--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,13 @@ fn main() {
         .header("wrapper.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .clang_args(&["-I", "sleuthkit"])
+        .derive_debug(true)
+        .derive_default(true)
+        
         .whitelist_function("tsk_error_get")
         
         .whitelist_function("tsk_img_open_utf8_sing")
+        .whitelist_function("tsk_img_open_external")
         .whitelist_function("tsk_img_close")
 
         .whitelist_function("tsk_vs_open")

--- a/src/tsk_img.rs
+++ b/src/tsk_img.rs
@@ -15,6 +15,14 @@ pub struct TskImg {
     pub handle: NonNull<tsk::TSK_IMG_INFO>
 }
 impl TskImg {
+    /// Create a TskImg wrapper from a given TSK_IMG_INFO NonNull pinter.
+    /// 
+    pub fn from_tsk_img_info_ptr(img_info: NonNull<tsk::TSK_IMG_INFO>) -> Self {
+        Self {
+            handle: img_info
+        }
+    }
+
     /// Create a TskImg wrapper from a given source.
     /// 
     pub fn from_source(source: &str) -> Result<Self, TskError> {


### PR DESCRIPTION
## [0.1.0]
### Added
- `TskImg::from_tsk_img_info_ptr()` to create a TskImg from `NonNull<tsk::TSK_IMG_INFO>`
- imported `tsk_img_open_external` tsk function
- imported tsk structs now derive debug and default
